### PR TITLE
Added commands to convert to \xFF \uFFFF \UFFFFFFFF forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,24 @@
         "vscode": "^1.1.5",
         "@types/node": "^7.0.43",
         "@types/mocha": "^2.2.42"
+    },
+    "contributes": {
+        "commands": [
+            {
+                "category": "CursorCharCode",
+                "command": "cursorCharCode.convertToXX",
+                "title": "Replace character to \\xFF form"
+            },
+            {
+                "category": "CursorCharCode",
+                "command": "cursorCharCode.convertToXXXX",
+                "title": "Replace character to \\uFFFF form"
+            },
+            {
+                "category": "CursorCharCode",
+                "command": "cursorCharCode.convertToXXXXXXXX",
+                "title": "Replace character to \\UFFFFFFFF form"
+            }
+        ]
     }
 }


### PR DESCRIPTION
| char | \xFF | \uFFFF | \UFFFFFFFF |
| --- | --- | --- | --- |
| a | \x61 | \u0061 | \U00000061 |
| ア | \xe3\x82\xa2 | \u30a2 | \U000030a2 |
| 🍪 | \xf0\x9f\x8d\xaa | \ud83c\udf6a | \U0001f36a |

`\xFF` form is used in native programs and languages with utf8 strings
`\uFFFF` form is used in JS
`\UFFFFFFFF` form can be used additionally to `\xFF` form in [D](https://dlang.org). Also useful to just insert the code in the editor.

Also if you add this to the changelog, I recommend moving the newest versions to the top instead because that's what's showed first on the marketplace.