### PR TITLE
Move status bar item to the right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to the "cursorCharCode" extension will be documented in this file.
 
+### v0.2.2 (14/12/2022)
+- control is now aligned to the right of the status bar
+
 ### v0.2.1 (08/12/2022)
 - character name tooltip
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
     "name": "cursorCharCode",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cursorCharCode",
-            "version": "0.2.1",
-            "license": "SEE LICENSE IN LICENSE.txt",
+            "version": "0.2.2",
             "dependencies": {
                 "unicode": "^14.0.0",
                 "unicode-properties": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cursorCharCode",
     "displayName": "Unicode code point of current character",
     "description": "Shows the Unicode code point of character under cursor in the status bar.",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "publisher": "zeithaste",
     "engines": {
         "vscode": "^1.34.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,3 +212,4 @@ class CharCodeController {
         this._display.updateCharacterCode();
     }
 }
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,7 +134,7 @@ class CharCodeDisplay {
 
     public updateCharacterCode(editor?: TextEditor) {
         if (!this._statusBarItem) {
-            this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
+            this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 101);
         }
 
         // Get the current text editor


### PR DESCRIPTION
The character info should now be next to the line/column display (number value by try & error & retry same & other error...). The left side of the status bar is already pretty crowded with project actions and the right side seems more for the editor itself, so I find it more appropriate to put it there.